### PR TITLE
A bunch of four small features

### DIFF
--- a/TSClientGen.Contract/TSIgnoreAttribute.cs
+++ b/TSClientGen.Contract/TSIgnoreAttribute.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace TSClientGen
+{
+	/// <summary>
+	/// For applying to api method, its parameter or to a property of a model class.
+	/// Excludes api method, api method parameter or the property of a type from TypeScript code generation.
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Method | AttributeTargets.Parameter | AttributeTargets.Property)]
+	public class TSIgnoreAttribute : Attribute
+	{
+	}
+}

--- a/TSClientGen.Core/IApiDiscovery.cs
+++ b/TSClientGen.Core/IApiDiscovery.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Reflection;
 using TSClientGen.Extensibility.ApiDescriptors;
@@ -13,6 +12,6 @@ namespace TSClientGen
 		/// <summary>
 		/// Constructs module descriptors for the api found in the assembly 
 		/// </summary>
-		IEnumerable<ApiClientModule> GetModules(Assembly assembly, Func<Type, bool> processModule);
+		IEnumerable<ApiClientModule> GetModules(Assembly assembly);
 	}
 }

--- a/TSClientGen.Core/IArguments.cs
+++ b/TSClientGen.Core/IArguments.cs
@@ -8,6 +8,7 @@ namespace TSClientGen
 		bool CleanupOutDir { get; set; }
 		IEnumerable<string> AssemblyPaths { get; set; }
 		string EnumsModuleName { get; set; }
+		bool UseStringEnums { get; set; }
 		string CommonModuleName { get; set; }
 		bool AppendIPrefix { get; set; }
 		string GetResourceModuleName { get; set; }

--- a/TSClientGen.Core/ModuleGenerators/ApiModuleGenerator.cs
+++ b/TSClientGen.Core/ModuleGenerators/ApiModuleGenerator.cs
@@ -67,7 +67,7 @@ namespace TSClientGen
 				var methodWriter = new ApiMethodGenerator(method, _result, _typeMapping);
 				methodWriter.ResolveConflictingParamNames(imports);
 				if (method.GenerateUrl)
-				{					
+				{
 					writeMethod(
 						() => methodWriter.WriteGetUrlSignature(), 
 						() => methodWriter.WriteBody(true, _apiClientModule.SupportsExternalHost));

--- a/TSClientGen.Core/ModuleGenerators/EnumModuleGenerator.cs
+++ b/TSClientGen.Core/ModuleGenerators/EnumModuleGenerator.cs
@@ -9,6 +9,7 @@ namespace TSClientGen
 	{		
 		public void Write(
 			IEnumerable<Type> enumTypes,
+			bool useStringEnums,
 			string getResourceModuleName,
 			ILookup<Type, TSExtendEnumAttribute> staticMemberProvidersByEnum)
 		{
@@ -17,7 +18,7 @@ namespace TSClientGen
 
 			foreach (var @enum in enumTypes)
 			{
-				writeEnum(@enum);
+				writeEnum(@enum, useStringEnums);
 
 				if (staticMemberProvidersByEnum[@enum].Any())
 				{
@@ -53,7 +54,7 @@ namespace TSClientGen
 			}
 		}
 
-		private void writeEnum(Type enumType)
+		private void writeEnum(Type enumType, bool useStringEnums)
 		{
 			var names = Enum.GetNames(enumType);
 			var underlyingType = Enum.GetUnderlyingType(enumType);
@@ -62,7 +63,9 @@ namespace TSClientGen
 
 			foreach (string name in names)
 			{
-				var value = Convert.ChangeType(Enum.Parse(enumType, name), underlyingType);
+				var value = useStringEnums
+					? $"'{name}'"
+					: Convert.ChangeType(Enum.Parse(enumType, name), underlyingType);
 				_result.AppendLine($"{name} = {value},");
 			}
 

--- a/TSClientGen.Core/Runner.cs
+++ b/TSClientGen.Core/Runner.cs
@@ -67,7 +67,10 @@ namespace TSClientGen
 				}
 			}
 
-			generateEnumsModule(allEnums, enumStaticMemberProviders, enumsModuleName);
+			if (allEnums.Any())
+			{
+				generateEnumsModule(allEnums, enumStaticMemberProviders, enumsModuleName);
+			}
 
 			if (_arguments.CleanupOutDir)
 			{
@@ -99,9 +102,7 @@ namespace TSClientGen
 				.ToDictionary(attr => attr.ModuleName);
 			
 			// generating client modules for api controllers
-			var modules = _apiDiscovery.GetModules(
-				assembly, 
-				t => t.GetCustomAttribute<TSModuleAttribute>() != null);
+			var modules = _apiDiscovery.GetModules(assembly);
 			foreach (var module in modules)
 			{
 				if (moduleNames.Contains(module.Name))

--- a/TSClientGen.Core/Runner.cs
+++ b/TSClientGen.Core/Runner.cs
@@ -177,7 +177,7 @@ namespace TSClientGen
 				enumsModuleName = enumsModuleName.Remove(enumsModuleName.Length - 3);
 			
 			var enumModuleGenerator = new EnumModuleGenerator();
-			enumModuleGenerator.Write(enums, _arguments.GetResourceModuleName, staticMemberProvidersLookup);
+			enumModuleGenerator.Write(enums, _arguments.UseStringEnums, _arguments.GetResourceModuleName, staticMemberProvidersLookup);
 			writeFile(enumsModuleName + ".ts", enumModuleGenerator.GetResult());
 
 			var enumLocalizationAttributes = staticMemberProviders.OfType<TSEnumLocalizationAttribute>().ToList();

--- a/TSClientGen.Core/TypeMapping.cs
+++ b/TSClientGen.Core/TypeMapping.cs
@@ -220,6 +220,7 @@ namespace TSClientGen
 		private TypeDescriptor createInterfaceDescriptor(Type type)
 		{
 			var properties = type.GetProperties(BindingFlags.Instance | BindingFlags.Public)
+				.Where(p => p.GetCustomAttribute<TSIgnoreAttribute>() == null)
 				.Select(p => new { Descriptor = createPropertyDescriptor(p), Property = p })
 				.Where(p => p.Descriptor != null)
 				.ToList();

--- a/TSClientGen.Core/TypeMapping.cs
+++ b/TSClientGen.Core/TypeMapping.cs
@@ -75,8 +75,7 @@ namespace TSClientGen
 			_typeDefinitions.Add(type, writeInterface(tsTypeName, descriptor));
 			AddType(descriptor.BaseType);
 
-			var requireDescendantsAttr = type.GetCustomAttributes<TSRequireDescendantTypes>().FirstOrDefault();
-			if (requireDescendantsAttr != null)
+			foreach (var requireDescendantsAttr in type.GetCustomAttributes<TSRequireDescendantTypes>())
 			{
 				var targetAsm = requireDescendantsAttr.IncludeDescendantsFromAssembly?.Assembly ?? type.Assembly;
 				var inheritedTypes = targetAsm.GetTypes().Where(type.IsAssignableFrom).ToList();

--- a/TSClientGen.Extensibility/ApiDescriptors/ApiClientModule.cs
+++ b/TSClientGen.Extensibility/ApiDescriptors/ApiClientModule.cs
@@ -12,18 +12,14 @@ namespace TSClientGen.Extensibility.ApiDescriptors
 	public class ApiClientModule
 	{
 		public ApiClientModule(
+			string moduleName,
 			string apiClientClassName,
 			IReadOnlyCollection<ApiMethod> methods,
 			Type controllerType)
 		{
+			Name = moduleName;
 			ApiClientClassName = apiClientClassName;
 			Methods = methods;
-
-			var tsModuleAttribute = controllerType.GetCustomAttribute<TSModuleAttribute>();
-			if (tsModuleAttribute == null)
-				throw new ArgumentException("TSModuleAttribute must be applied to the controller type");
-
-			Name = tsModuleAttribute.ModuleName;
 
 			var additionalTypes = new List<Type>();
 			foreach (var requireTypeAttr in controllerType.GetCustomAttributes<TSRequireTypeAttribute>())

--- a/TSClientGen.Tests/ApiModuleGeneratorTests.cs
+++ b/TSClientGen.Tests/ApiModuleGeneratorTests.cs
@@ -24,6 +24,17 @@ namespace TSClientGen.Tests
 		}
 
 		[Test]
+		public void Adding_type_to_mapping_adds_all_descenand_types_if_attribute_specified()
+		{
+			var mapping = new TypeMapping();
+			mapping.AddType(typeof(BaseClass));
+
+			CollectionAssert.AreEquivalent(
+				new[] {typeof(BaseClass), typeof(Descendant1), typeof(Descendant2)},
+				mapping.GetGeneratedTypes().Keys);
+		}
+
+		[Test]
 		public void All_nested_types_are_written_to_module()
 		{
 			var mapping = new TypeMapping();
@@ -154,6 +165,13 @@ namespace TSClientGen.Tests
 		{
 			public Enum2 EnumProp { get; } 			
 		}
+
+		[TSRequireDescendantTypes]
+		class BaseClass {}
+
+		class Descendant1 : BaseClass {}
+
+		class Descendant2 : BaseClass {}
 
 		enum Enum1 { A, B }
 

--- a/TSClientGen.Tests/ApiModuleGeneratorTests.cs
+++ b/TSClientGen.Tests/ApiModuleGeneratorTests.cs
@@ -132,7 +132,7 @@ namespace TSClientGen.Tests
 
 		private ApiModuleGenerator createGenerator(TypeMapping typeMapping, IApiClientWriter customWriter = null)
 		{
-			var module = new ApiClientModule("client", new ApiMethod[0], typeof(Controller));
+			var module = new ApiClientModule("client", "client", new ApiMethod[0], typeof(Controller));
 			return new ApiModuleGenerator(
 				module,
 				typeMapping,
@@ -142,7 +142,6 @@ namespace TSClientGen.Tests
 		}
 		
 		
-		[TSModule("api")]
 		class Controller {}
 		
 		class Model

--- a/TSClientGen.Tests/TextAssert.cs
+++ b/TSClientGen.Tests/TextAssert.cs
@@ -13,5 +13,19 @@ namespace TSClientGen.Tests
 				output.Split(Environment.NewLine).Select(s => s.Trim('\t')).ToList(),
 				$"Expected line '{expectedLine}' not found\nActual output: \n{output}");
 		}
+
+		public static void ContainsLinesInCorrectOrder(string output, params string[] expectedLines)
+		{
+			var actualLines = output.Split(Environment.NewLine).Select(s => s.Trim('\t')).ToList();
+			int ix = 0;
+			foreach (var expectedLine in expectedLines)
+			{
+				ix = actualLines.IndexOf(expectedLine, ix);
+				if (ix == -1)
+					Assert.Fail($"Expected line '{expectedLine}' not found in correct order\nActual output: \n{output}");
+
+				ix++;
+			}
+		}
 	}
 }

--- a/TSClientGen.Tests/TextAssert.cs
+++ b/TSClientGen.Tests/TextAssert.cs
@@ -14,6 +14,14 @@ namespace TSClientGen.Tests
 				$"Expected line '{expectedLine}' not found\nActual output: \n{output}");
 		}
 
+		public static void DoesNotContainLine(string notExpectedLine, string output)
+		{
+			CollectionAssert.DoesNotContain(
+				output.Split(Environment.NewLine).Select(s => s.Trim('\t')).ToList(),
+				notExpectedLine,
+				$"Found line '{notExpectedLine}' that shouldn't be there\nActual output: \n{output}");
+		}
+
 		public static void ContainsLinesInCorrectOrder(string output, params string[] expectedLines)
 		{
 			var actualLines = output.Split(Environment.NewLine).Select(s => s.Trim('\t')).ToList();

--- a/TSClientGen.Tests/TypeConversionTests.cs
+++ b/TSClientGen.Tests/TypeConversionTests.cs
@@ -44,6 +44,17 @@ namespace TSClientGen.Tests
 		}
 
 		[Test]
+		public void Ignored_properties_are_excluded_from_code_generation()
+		{
+			var mapping = new TypeMapping();
+			mapping.AddType(typeof(SimpleModel));
+
+			var generatedType = mapping.GetGeneratedTypes()[typeof(SimpleModel)]; 
+			TextAssert.ContainsLine("prop1: string;", generatedType);
+			TextAssert.DoesNotContainLine("prop2: string;", generatedType);
+		}
+
+		[Test]
 		public void Generic_types_are_mapped_correctly()
 		{
 			var mapping = new TypeMapping();
@@ -124,6 +135,10 @@ namespace TSClientGen.Tests
 		// ReSharper disable once ClassNeverInstantiated.Local
 		class SimpleModel
 		{
+			public string Prop1 { get; }
+			
+			[TSIgnore]
+			public string Prop2 { get; }
 		}
 
 		class GenericModel<T>

--- a/TSClientGen/Arguments.cs
+++ b/TSClientGen/Arguments.cs
@@ -19,6 +19,9 @@ namespace TSClientGen
 
 		[Option("enum-module")]
 		public string EnumsModuleName { get; set; }
+		
+		[Option("string-enums")]
+		public bool UseStringEnums { get; set; }		
 
 		[Option("common-module")]
 		public string CommonModuleName { get; set; }

--- a/TSClientGen/AspNetWebApi/ApiDiscovery.cs
+++ b/TSClientGen/AspNetWebApi/ApiDiscovery.cs
@@ -63,6 +63,9 @@ namespace TSClientGen.AspNetWebApi
 			if (route == null)
 				return null;
 
+			if (method.GetCustomAttribute<TSIgnoreAttribute>() != null)
+				return null;
+
 			var actionHttpMethodAttr = method.GetCustomAttributes().OfType<IActionHttpMethodProvider>().FirstOrDefault();
 			var httpVerb = getVerb(actionHttpMethodAttr);
 			if (httpVerb == null)
@@ -70,6 +73,7 @@ namespace TSClientGen.AspNetWebApi
 			
 			var parameters = method.GetParameters()
 				.Where(p => p.ParameterType != typeof(CancellationToken))
+				.Where(p => p.GetCustomAttribute<TSIgnoreAttribute>() == null)
 				.Select(p => new ApiMethodParam(
 					p.Name,
 					p.ParameterType,


### PR DESCRIPTION
- Support for generating enums with string values in TypeScript
- Generate api client modules for all found api controllers if no one of them has TSModule attribute applied (thus a reference to TSClientGen.Contract is no more required in a web api assembly with controllers)
- Support multiple TSRequireDescendantTypes attributes on a type (to collect descendant types from different assemblies)
- Add TSIgnore attribute that allows excluding type properties, api controller methods and method parameters from TypeScript code generation.
