### PR TITLE
DEV-18119 [dotnet] Upgrade to .NET10

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -9,7 +9,7 @@
       ]
     },
     "paket": {
-      "version": "8.0.3",
+      "version": "10.3.1",
       "commands": [
         "paket"
       ]

--- a/.paket/Paket.Restore.targets
+++ b/.paket/Paket.Restore.targets
@@ -235,14 +235,16 @@
 				<Splits>$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',').Length)</Splits>
 				<PackageName>$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[0])</PackageName>
 				<PackageVersion>$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[1])</PackageVersion>
+				<Reference>$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[2])</Reference>
 				<AllPrivateAssets>$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[4])</AllPrivateAssets>
 				<CopyLocal Condition="%(PaketReferencesFileLinesInfo.Splits) &gt;= 6">$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[5])</CopyLocal>
 				<OmitContent Condition="%(PaketReferencesFileLinesInfo.Splits) &gt;= 7">$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[6])</OmitContent>
 				<ImportTargets Condition="%(PaketReferencesFileLinesInfo.Splits) &gt;= 8">$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[7])</ImportTargets>
 				<Aliases Condition="%(PaketReferencesFileLinesInfo.Splits) &gt;= 9">$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[8])</Aliases>
+				<ReferenceCondition Condition="%(PaketReferencesFileLinesInfo.Splits) &gt;= 10">$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[9])</ReferenceCondition>
 			</PaketReferencesFileLinesInfo>
-			<PackageReference Include="%(PaketReferencesFileLinesInfo.PackageName)">
-				<Version>%(PaketReferencesFileLinesInfo.PackageVersion)</Version>
+			<PackageReference Condition=" ('$(ManagePackageVersionsCentrally)' != 'true' Or '%(PaketReferencesFileLinesInfo.Reference)' == 'Direct') AND ('%(PaketReferencesFileLinesInfo.ReferenceCondition)' == 'true' Or $(%(PaketReferencesFileLinesInfo.ReferenceCondition)) == 'true')" Include="%(PaketReferencesFileLinesInfo.PackageName)">
+				<Version Condition=" '$(ManagePackageVersionsCentrally)' != 'true' ">%(PaketReferencesFileLinesInfo.PackageVersion)</Version>
 				<PrivateAssets Condition=" ('%(PaketReferencesFileLinesInfo.AllPrivateAssets)' == 'true') Or ('$(PackAsTool)' == 'true') ">All</PrivateAssets>
 				<ExcludeAssets Condition=" %(PaketReferencesFileLinesInfo.CopyLocal) == 'false' or %(PaketReferencesFileLinesInfo.AllPrivateAssets) == 'exclude'">runtime</ExcludeAssets>
 				<ExcludeAssets Condition=" %(PaketReferencesFileLinesInfo.OmitContent) == 'true'">$(ExcludeAssets);contentFiles</ExcludeAssets>
@@ -250,8 +252,10 @@
 				<Aliases Condition=" %(PaketReferencesFileLinesInfo.Aliases) != ''">%(PaketReferencesFileLinesInfo.Aliases)</Aliases>
 				<Publish Condition=" '$(PackAsTool)' == 'true' ">true</Publish>
 				<AllowExplicitVersion>true</AllowExplicitVersion>
-
 			</PackageReference>
+			<PackageVersion Condition="('$(ManagePackageVersionsCentrally)' != 'true' Or '%(PaketReferencesFileLinesInfo.Reference)' == 'Direct') AND ('%(PaketReferencesFileLinesInfo.ReferenceCondition)' == 'true' Or $(%(PaketReferencesFileLinesInfo.ReferenceCondition)) == 'true')" Include="%(PaketReferencesFileLinesInfo.PackageName)">
+				<Version>%(PaketReferencesFileLinesInfo.PackageVersion)</Version>
+			</PackageVersion>
 		</ItemGroup>
 
 		<PropertyGroup>
@@ -314,7 +318,17 @@
 		</ItemGroup>
 
 		<Error Text="Error Because of PAKET_ERROR_ON_MSBUILD_EXEC (not calling fix-nuspecs)" Condition=" '$(PAKET_ERROR_ON_MSBUILD_EXEC)' == 'true' " />
-		<Exec Condition="@(_NuspecFiles) != ''" Command='$(PaketCommand) fix-nuspecs files "@(_NuspecFiles)" project-file "$(PaketProjectFile)" ' />
+		<Exec Condition="@(_NuspecFiles) != ''" Command='$(PaketCommand) show-conditions -s' ConsoleToMSBuild="true" StandardOutputImportance="low">
+			<Output TaskParameter="ConsoleOutput" ItemName="_ConditionProperties"/>
+		</Exec>
+		<ItemGroup>
+			<_DefinedConditionProperties Include="@(_ConditionProperties)" Condition="$(%(Identity)) == 'true'"/>
+		</ItemGroup>
+		<PropertyGroup>
+			<_ConditionsParameter></_ConditionsParameter>
+			<_ConditionsParameter Condition="@(_DefinedConditionProperties) != ''">--conditions @(_DefinedConditionProperties)</_ConditionsParameter>
+		</PropertyGroup>
+		<Exec Condition="@(_NuspecFiles) != ''" Command='$(PaketCommand) fix-nuspecs files "@(_NuspecFiles)" project-file "$(PaketProjectFile)" $(_ConditionsParameter)' />
 		<Error Condition="@(_NuspecFiles) == ''" Text='Could not find nuspec files in "$(AdjustedNuspecOutputPath)" (Version: "$(PackageVersion)"), therefore we cannot call "paket fix-nuspecs" and have to error out!' />
 
 		<ConvertToAbsolutePath Condition="@(_NuspecFiles) != ''" Paths="@(_NuspecFiles)">

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,8 @@
 # Release Notes
 
+## 10.1.1 - 2025-01-28
+- Add net 10.0 to TFMs
+
 ## 10.1.0 - 2024-10-01
 - New `GetApiClientConstructorParams` method has been added to the `IApiClientWriter` interface to override the constructor parameters of the generated client.
 

--- a/TSClientGen.Contract/Properties/AssemblyInfo.cs
+++ b/TSClientGen.Contract/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 ﻿using System.Reflection;
 
-[assembly: AssemblyVersion("10.1.0")]
-[assembly: AssemblyInformationalVersion("10.1.0")]
+[assembly: AssemblyVersion("10.1.1")]
+[assembly: AssemblyInformationalVersion("10.1.1")]
 
 [assembly: AssemblyTitle("TSClientGen.Contract")]
 [assembly: AssemblyDescription("Contracts assembly with attributes for decorating api for TSClientGen tool")]

--- a/TSClientGen.Core/Properties/AssemblyInfo.cs
+++ b/TSClientGen.Core/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 ﻿using System.Reflection;
 
-[assembly: AssemblyVersion("10.1.0")]
-[assembly: AssemblyInformationalVersion("10.1.0")]
+[assembly: AssemblyVersion("10.1.1")]
+[assembly: AssemblyInformationalVersion("10.1.1")]
 
 [assembly: AssemblyTitle("TSClientGen.Core")]
 [assembly: AssemblyDescription("Main assembly with the code generation stuff")]

--- a/TSClientGen.Extensibility/Properties/AssemblyInfo.cs
+++ b/TSClientGen.Extensibility/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 ﻿using System.Reflection;
 
-[assembly: AssemblyVersion("10.1.0")]
-[assembly: AssemblyInformationalVersion("10.1.0")]
+[assembly: AssemblyVersion("10.1.1")]
+[assembly: AssemblyInformationalVersion("10.1.1")]
 
 [assembly: AssemblyTitle("TSClientGen.Extensibility")]
 [assembly: AssemblyDescription("Contracts assembly for authoring plugins for TSClientGen tool")]

--- a/TSClientGen.Tests/Properties/AssemblyInfo.cs
+++ b/TSClientGen.Tests/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 ﻿using System.Reflection;
 
-[assembly: AssemblyVersion("10.1.0")]
-[assembly: AssemblyInformationalVersion("10.1.0")]
+[assembly: AssemblyVersion("10.1.1")]
+[assembly: AssemblyInformationalVersion("10.1.1")]
 
 [assembly: AssemblyTitle("TSClientGen.Tests")]
 [assembly: AssemblyDescription("Unit tests for TSClientGen tool")]

--- a/TSClientGen/TSClientGen.csproj
+++ b/TSClientGen/TSClientGen.csproj
@@ -7,12 +7,12 @@
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>tsclientgen</ToolCommandName>
-    <PackageVersion>10.1.0</PackageVersion>
+    <PackageVersion>10.1.1</PackageVersion>
     <Authors>Smartcat</Authors>
     <Description>Tool to generate TypeScript clients for ASP.NET Core web APIs</Description>
     <RepositoryUrl>https://github.com/smartcatai/ts-client-gen</RepositoryUrl>
     <PackageLicenseUrl>https://github.com/smartcatai/ts-client-gen/blob/develop/LICENSE.txt</PackageLicenseUrl>
-    <TargetFrameworks>net8.0;net7.0;net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net10.0;net8.0;net7.0;net5.0;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\TSClientGen.Contract\TSClientGen.Contract.csproj" />


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds .NET 10 support and updates build tooling.
> 
> - **TFMs**: Add `net10.0` to `TSClientGen.csproj`
> - **Versioning**: Bump package and assembly versions to `10.1.1`; update `RELEASE_NOTES.md`
> - **Tooling**: Upgrade `paket` CLI to `10.3.1`
> - **Build targets**: Enhance `Paket.Restore.targets` to handle central package management (`ManagePackageVersionsCentrally`), conditional references (`Reference`, `ReferenceCondition`), emit `<PackageVersion>` items, and pass dynamic conditions to `fix-nuspecs` via `show-conditions`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b88796fb6a6f672501684007a870f03f7e35c1c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->